### PR TITLE
Resolve resize issue under Qt 6 environment. 

### DIFF
--- a/app/framelesswindow.cpp
+++ b/app/framelesswindow.cpp
@@ -119,7 +119,11 @@ bool FramelessWindow::mousePress(QMouseEvent* event)
     if (event->buttons() & Qt::LeftButton && !isMaximized())
     {
         QWindow* win = window()->windowHandle();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         Qt::Edges edges = this->getEdgesByPos(event->globalPosition().toPoint(), win->frameGeometry());
+#else
+        Qt::Edges edges = this->getEdgesByPos(event->globalPos(), win->frameGeometry());
+#endif // QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         if (edges)
         {
             win->startSystemResize(edges);

--- a/app/framelesswindow.cpp
+++ b/app/framelesswindow.cpp
@@ -71,16 +71,12 @@ bool FramelessWindow::eventFilter(QObject* o, QEvent* e)
     {
         QWidget* wg = qobject_cast<QWidget*>(o);
         if (wg != nullptr)
-        {
             return mouseHover(static_cast<QHoverEvent*>(e), wg);
-        }
+
         break;
     }
     case QEvent::MouseButtonPress:
-    {
         return mousePress(static_cast<QMouseEvent*>(e));
-        break;
-    }
     }
 
     return QWidget::eventFilter(o, e);
@@ -93,20 +89,17 @@ bool FramelessWindow::mouseHover(QHoverEvent* event, QWidget* wg)
 
     // backup & restore cursor shape
     if (edges && !m_oldEdges)
-    {
         // entering the edge. backup cursor shape
         m_oldCursorShape = win->cursor().shape();
-    }
     if (!edges && m_oldEdges)
-    {
         // leaving the edge. restore cursor shape
         win->setCursor(m_oldCursorShape);
-    }
+
+    // save the latest edges status
     m_oldEdges = edges;
 
     // show resize cursor shape if cursor is within border
-    if (edges)
-    {
+    if (edges) {
         win->setCursor(this->getCursorByEdge(edges, Qt::ArrowCursor));
         return true;
     }
@@ -116,16 +109,14 @@ bool FramelessWindow::mouseHover(QHoverEvent* event, QWidget* wg)
 
 bool FramelessWindow::mousePress(QMouseEvent* event)
 {
-    if (event->buttons() & Qt::LeftButton && !isMaximized())
-    {
+    if (event->buttons() & Qt::LeftButton && !isMaximized()) {
         QWindow* win = window()->windowHandle();
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         Qt::Edges edges = this->getEdgesByPos(event->globalPosition().toPoint(), win->frameGeometry());
 #else
         Qt::Edges edges = this->getEdgesByPos(event->globalPos(), win->frameGeometry());
 #endif // QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-        if (edges)
-        {
+        if (edges) {
             win->startSystemResize(edges);
             return true;
         }
@@ -136,11 +127,16 @@ bool FramelessWindow::mousePress(QMouseEvent* event)
 
 Qt::CursorShape FramelessWindow::getCursorByEdge(const Qt::Edges& edges, Qt::CursorShape default_cursor)
 {
-    if ((edges == (Qt::TopEdge | Qt::LeftEdge)) || (edges == (Qt::RightEdge | Qt::BottomEdge))) return Qt::SizeFDiagCursor;
-    else if ((edges == (Qt::TopEdge | Qt::RightEdge)) || (edges == (Qt::LeftEdge | Qt::BottomEdge))) return Qt::SizeBDiagCursor;
-    else if (edges & (Qt::TopEdge | Qt::BottomEdge)) return Qt::SizeVerCursor;
-    else if (edges & (Qt::LeftEdge | Qt::RightEdge)) return Qt::SizeHorCursor;
-    else return default_cursor;
+    if ((edges == (Qt::TopEdge | Qt::LeftEdge)) || (edges == (Qt::RightEdge | Qt::BottomEdge)))
+        return Qt::SizeFDiagCursor;
+    else if ((edges == (Qt::TopEdge | Qt::RightEdge)) || (edges == (Qt::LeftEdge | Qt::BottomEdge)))
+        return Qt::SizeBDiagCursor;
+    else if (edges & (Qt::TopEdge | Qt::BottomEdge))
+        return Qt::SizeVerCursor;
+    else if (edges & (Qt::LeftEdge | Qt::RightEdge))
+        return Qt::SizeHorCursor;
+    else
+        return default_cursor;
 }
 
 Qt::Edges FramelessWindow::getEdgesByPos(const QPoint gpos, const QRect& winrect)
@@ -151,10 +147,14 @@ Qt::Edges FramelessWindow::getEdgesByPos(const QPoint gpos, const QRect& winrect
     int x = gpos.x() - winrect.x();
     int y = gpos.y() - winrect.y();
 
-    if (x < borderWidth) edges |= Qt::LeftEdge;
-    if (x > (winrect.width() - borderWidth)) edges |= Qt::RightEdge;
-    if (y < borderWidth) edges |= Qt::TopEdge;
-    if (y > (winrect.height() - borderWidth)) edges |= Qt::BottomEdge;
+    if (x < borderWidth)
+        edges |= Qt::LeftEdge;
+    if (x > (winrect.width() - borderWidth))
+        edges |= Qt::RightEdge;
+    if (y < borderWidth)
+        edges |= Qt::TopEdge;
+    if (y > (winrect.height() - borderWidth))
+        edges |= Qt::BottomEdge;
 
     return edges;
 }

--- a/app/framelesswindow.cpp
+++ b/app/framelesswindow.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2022 Gary Wang <wzc782970009@gmail.com>
+// SPDX-FileCopyrightText: 2023 Tad Young <yyc12321@outlook.com>
 //
 // SPDX-License-Identifier: MIT
 
@@ -10,10 +11,6 @@
 #include <QVBoxLayout>
 #include <QWindow>
 
-#ifdef _WIN32
-#include <windows.h>
-#endif // _WIN32
-
 FramelessWindow::FramelessWindow(QWidget *parent)
     : QWidget(parent)
     , m_centralLayout(new QVBoxLayout(this))
@@ -21,11 +18,6 @@ FramelessWindow::FramelessWindow(QWidget *parent)
     , m_oldEdges()
 {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    // The Qt::WindowMinMaxButtonsHint or Qt::WindowMinimizeButtonHint here is to
-    // provide the ability to use Winkey + Up/Down to toggle minimize/maximize.
-    // But a bug introduced in Qt6 that this flag will break the WM_NCHITTEST event.
-    // See: QTBUG-112356 and discussion in https://github.com/BLumia/pineapple-pictures/pull/81
-    // Thanks @yyc12345 for finding out the source of the issue.
     this->setWindowFlags(Qt::Window | Qt::FramelessWindowHint | Qt::WindowMinMaxButtonsHint);
 #else
     // There is a bug in Qt 5 that will make pressing Meta+Up cause the app
@@ -50,14 +42,6 @@ void FramelessWindow::setCentralWidget(QWidget *widget)
     m_centralLayout->addWidget(widget);
     m_centralWidget = widget;
 }
-
-/*
- * The references of following functions
- * https://stackoverflow.com/questions/411823/how-do-i-implement-qhoverevent-in-qt
- * https://stackoverflow.com/questions/74155493/how-can-i-resize-frameless-window-in-qml
- * https://gist.github.com/Nico-Duduf/b8c799f1f2a694732abd1238843b1d70
- * https://stackoverflow.com/questions/2445997/qgraphicsview-and-eventfilter
-*/
 
 void FramelessWindow::installResizeCapture(QObject* widget)
 {

--- a/app/framelesswindow.h
+++ b/app/framelesswindow.h
@@ -25,10 +25,25 @@ public:
 
     void setCentralWidget(QWidget * widget);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 protected:
-    bool nativeEvent(const QByteArray& eventType, void* message, NATIVE_RESULT* result) override;
+    bool event(QEvent* e) override;
+
+protected slots:
+    void mousePressEvent(QMouseEvent *event) override;
+#endif
 
 private:
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    Qt::Edges m_oldEdges;
+    Qt::CursorShape m_oldCursorShape;
+
+    void hoverMove(QHoverEvent* event);
+
+    Qt::CursorShape getCursorByEdge(const Qt::Edges& edges, Qt::CursorShape default_cursor);
+    Qt::Edges getEdgesByPos(const QPoint pos, const QRect& winrect);
+#endif
+
     QVBoxLayout * m_centralLayout = nullptr;
     QWidget * m_centralWidget = nullptr; // just a pointer, doesn't take the ownership.
 };

--- a/app/framelesswindow.h
+++ b/app/framelesswindow.h
@@ -7,12 +7,6 @@
 
 #include <QWidget>
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    typedef qintptr NATIVE_RESULT;
-#else
-    typedef long NATIVE_RESULT;
-#endif // QT_VERSION_CHECK(6, 0, 0)
-
 QT_BEGIN_NAMESPACE
 class QVBoxLayout;
 QT_END_NAMESPACE
@@ -24,25 +18,19 @@ public:
     explicit FramelessWindow(QWidget *parent = nullptr);
 
     void setCentralWidget(QWidget * widget);
+    void installResizeCapture(QObject* widget);
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 protected:
-    bool event(QEvent* e) override;
-
-protected slots:
-    void mousePressEvent(QMouseEvent *event) override;
-#endif
+    bool eventFilter(QObject *o, QEvent *e) override;
+    bool mouseHover(QHoverEvent* event, QWidget* wg);
+    bool mousePress(QMouseEvent* event);
 
 private:
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     Qt::Edges m_oldEdges;
     Qt::CursorShape m_oldCursorShape;
 
-    void hoverMove(QHoverEvent* event);
-
     Qt::CursorShape getCursorByEdge(const Qt::Edges& edges, Qt::CursorShape default_cursor);
     Qt::Edges getEdgesByPos(const QPoint pos, const QRect& winrect);
-#endif
 
     QVBoxLayout * m_centralLayout = nullptr;
     QWidget * m_centralWidget = nullptr; // just a pointer, doesn't take the ownership.

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -162,6 +162,13 @@ MainWindow::MainWindow(QWidget *parent)
     QTimer::singleShot(0, this, [this](){
         m_am->setupShortcuts();
     });
+
+    // allow these widgets can go through some mouse events for resizing window.
+    installResizeCapture(m_closeButton);
+    installResizeCapture(m_graphicsView);
+    installResizeCapture(m_graphicsView->viewport());
+    installResizeCapture(m_gv);
+    installResizeCapture(m_gv->viewport());
 }
 
 MainWindow::~MainWindow()

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -163,7 +163,7 @@ MainWindow::MainWindow(QWidget *parent)
         m_am->setupShortcuts();
     });
 
-    // allow these widgets can go through some mouse events for resizing window.
+    // allow some mouse events can go through these widgets for resizing window.
     installResizeCapture(m_closeButton);
     installResizeCapture(m_graphicsView);
     installResizeCapture(m_graphicsView->viewport());


### PR DESCRIPTION
Qt 6 assume that `Qt::WindowMinMaxButtonsHint` depend on `Qt::WindowSystemMenuHint`. And hard-code this in its source code. Source code reference: https://github.com/qt/qtbase/blob/6.4.2/src/plugins/platforms/windows/qwindowswindow.cpp#L833

However, if `Qt::WindowSystemMenuHint` added, an extra window style called `WS_SYSMENU` will be added for this frameless window. Due to Windows implementation, if `WS_SYSMENU` existed, any resize operations of this window will fail, even `QWidget::nativeEvent()` was still running. 

I have tried `QWidget::setWindowFlag(Qt::WindowSystemMenuHint, false);` but it doesn't work. Obviously, we can remove `Qt::WindowMinMaxButtonsHint` to solve this issue. But we can not click icon on taskbar to minimize this window if removing it. This breaks the experience of this app, then I gave this up. 

So this is the final solution. I use native Win32 API to forced remove this annoying flag.

