### PR TITLE
chore: use std::as_const() instead of qAsConst

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ include (FeatureSummary)
 option (EXIV2_METADATA_SUPPORT "Better image metadata support via libexiv2" ON)
 option (PREFER_QT_5 "Prefer to use Qt 5 even if we have Qt 6" ON)
 
+set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
 set (CMAKE_AUTOMOC ON)
 set (CMAKE_AUTORCC ON)
 

--- a/app/playlistmanager.cpp
+++ b/app/playlistmanager.cpp
@@ -164,7 +164,7 @@ std::tuple<int, QUrl> PlaylistManager::currentFileUrl() const
 QList<QUrl> PlaylistManager::convertToUrlList(const QStringList &files)
 {
     QList<QUrl> urlList;
-    for (const QString & str : qAsConst(files)) {
+    for (const QString & str : std::as_const(files)) {
         QUrl url = QUrl::fromLocalFile(str);
         if (url.isValid()) {
             urlList.append(url);


### PR DESCRIPTION
Warning: constexpr typename std::add_const<_Tp>::type& qAsConst(T&) [with T = const QList<QString>; typename std::add_const<_Tp>::type = const QList<QString>]’ is deprecated: Use std::as_const() instead. [-Wdeprecated-declarations]