### PR TITLE
fix: window title not updated in some cases

### DIFF
--- a/app/graphicsview.h
+++ b/app/graphicsview.h
@@ -15,7 +15,7 @@ class GraphicsView : public QGraphicsView
 public:
     GraphicsView(QWidget *parent = nullptr);
 
-    void showFileFromPath(const QString &filePath, bool requestGallery = false);
+    void showFileFromPath(const QString &filePath);
 
     void showImage(const QPixmap &pixmap);
     void showImage(const QImage &image);
@@ -48,7 +48,6 @@ public:
 signals:
     void navigatorViewRequired(bool required, QTransform transform);
     void viewportRectChanged();
-    void requestGallery(const QString &filePath);
 
 public slots:
     void toggleCheckerboard(bool invertCheckerboardColor = false);
@@ -59,10 +58,6 @@ private:
     void mouseReleaseEvent(QMouseEvent * event) override;
     void wheelEvent(QWheelEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
-
-    void dragEnterEvent(QDragEnterEvent *event) override;
-    void dragMoveEvent(QDragMoveEvent *event) override;
-    void dropEvent(QDropEvent *event) override;
 
     bool isThingSmallerThanWindowWith(const QTransform &transform) const;
     bool shouldIgnoreMousePressMoveEvent(const QMouseEvent *event) const;

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -42,10 +42,9 @@ public:
     QUrl currentImageFileUrl() const;
 
     void clearGallery();
-    void loadGalleryBySingleLocalFile(const QString &path);
     void galleryPrev();
     void galleryNext();
-    void galleryCurrent();
+    void galleryCurrent(bool showLoadImageHintWhenEmpty);
 
     static QStringList supportedImageFormats();
 
@@ -60,6 +59,9 @@ protected slots:
     void wheelEvent(QWheelEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
     void contextMenuEvent(QContextMenuEvent *event) override;
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dragMoveEvent(QDragMoveEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
 
     void centerWindow();
     void closeWindow();

--- a/app/playlistmanager.h
+++ b/app/playlistmanager.h
@@ -80,6 +80,6 @@ signals:
     void totalCountChanged(int count);
 
 private:
-    int m_currentIndex;
+    int m_currentIndex = -1;
     PlaylistModel m_model;
 };


### PR DESCRIPTION
cc @yyc12345 

变更内容：

1. 把拖拽文件的事件处理从 graphicsview 挪出来到 mainwindow 了，这样 graphicsview 不需要关心到底需不需要更新 playlist（本来也不该关心，之前的写法sb）
2. 确保 modelreset 的时候也会试图更新标题，避免切换播放列表时，整个播放列表更新了但当前项下标不变导致不会触发当前项更新信号，使得标题不会更新的问题
3. 给了 m_currentIndex 一个默认值，这样首次一定会触发下标变化信号。
4. 将切换图片的逻辑从 `galleryCurrent` 挪到 `galleryPrev` 与 `galleryNext` 里，避免相同的图片被加载多次。