### PR TITLE
Fix incorrect syntax of COPY command in msvc-cmake-build.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,6 @@
 name: Windows CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   msvc-qmake-build:
@@ -103,7 +103,7 @@ jobs:
         windeployqt --verbose=2 --no-quick-import --no-translations --no-opengl-sw --no-system-d3d-compiler --no-system-dxc-compiler --skip-plugin-types tls,networkinformation build\bin\ppic.exe
         robocopy ./dependencies_bin/bin build/bin *.dll
         if ErrorLevel 8 (exit /B 1)
-        copy LICENSE build/bin/
+        copy LICENSE build\bin
         exit /B 0
     - uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
- Fix incorrect syntax of COPY which cause we fail to copy LICENSE in final distribution package.
- Add workflow_dispatch condition in workflow files to allow manual trigger (as BLumia requested).

The incorrect syntax of COPY command in msvc-cmake-build causes that we can not pack LICENSE file in distribution package and break the execution of subsequent commands (it's just a EXIT command in this upstream repository but it's different in my remix version).

If I execute `copy LICENSE build/bin/`, CMD will throw "The syntax of the command is incorrect". According to Microsoft document, I switch to use `copy LICENSE build/bin` but it's weird that CMD copy LICENSE to `build` directory, not `bin` subdirectory. So finally I gave up slash and use backslash instead, then I got the correct behavior.