### PR TITLE
feat: auto long image mode

### DIFF
--- a/app/graphicsview.h
+++ b/app/graphicsview.h
@@ -39,11 +39,19 @@ public:
     void displayScene();
     bool isSceneBiggerThanView() const;
     void setEnableAutoFitInView(bool enable = true);
+    void setLongImageMode(bool enable = true);
 
     bool avoidResetTransform() const;
     void setAvoidResetTransform(bool avoidReset);
 
     static QTransform resetScale(const QTransform & orig);
+
+    // Long image mode support
+    bool isLongImage() const;
+    bool shouldEnterLongImageMode() const;
+    void applyLongImageMode();
+    void applyLongImageModeDirect();
+    bool isInLongImageMode() const;
 
 signals:
     void navigatorViewRequired(bool required, QTransform transform);
@@ -70,6 +78,7 @@ private:
     // ... or even more? e.g. "fit/snap width" things...
     // Currently it's "no fit" when it's false and "fit when view is smaller" when it's true.
     bool m_enableFitInView = false;
+    bool m_longImageMode = false;
     bool m_avoidResetTransform = false;
     bool m_checkerboardEnabled = false;
     bool m_useLightCheckerboard = false;

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -700,6 +700,7 @@ void MainWindow::on_actionActualSize_triggered()
 {
     m_graphicsView->resetScale();
     m_graphicsView->setEnableAutoFitInView(false);
+    m_graphicsView->setLongImageMode(false);
 }
 
 void MainWindow::on_actionToggleMaximize_triggered()
@@ -728,6 +729,7 @@ void MainWindow::on_actionFitInView_triggered()
 {
     m_graphicsView->fitInView(m_gv->sceneRect(), Qt::KeepAspectRatio);
     m_graphicsView->setEnableAutoFitInView(m_graphicsView->scaleFactor() <= 1);
+    m_graphicsView->setLongImageMode(false);
 }
 
 void MainWindow::on_actionFitByWidth_triggered()
@@ -813,14 +815,12 @@ void MainWindow::on_actionRotateClockwise_triggered()
 {
     m_graphicsView->rotateView();
     m_graphicsView->displayScene();
-    m_gv->setVisible(false);
 }
 
 void MainWindow::on_actionRotateCounterClockwise_triggered()
 {
     m_graphicsView->rotateView(false);
     m_graphicsView->displayScene();
-    m_gv->setVisible(false);
 }
 
 void MainWindow::on_actionPrevPicture_triggered()

--- a/app/navigatorview.cpp
+++ b/app/navigatorview.cpp
@@ -9,6 +9,7 @@
 
 #include <QMouseEvent>
 #include <QDebug>
+#include <QTimer>
 
 NavigatorView::NavigatorView(QWidget *parent)
     : QGraphicsView (parent)
@@ -34,10 +35,14 @@ void NavigatorView::setOpacity(qreal opacity, bool animated)
 
 void NavigatorView::updateMainViewportRegion()
 {
-    if (m_mainView != nullptr) {
-        m_viewportRegion = mapFromScene(m_mainView->mapToScene(m_mainView->rect()));
-        update();
-    }
+    // Use QTimer::singleShot with lambda to delay the update
+    // This ensures all geometry updates are complete before calculating viewport region
+    QTimer::singleShot(0, [this]() {
+        if (m_mainView != nullptr) {
+            m_viewportRegion = mapFromScene(m_mainView->mapToScene(m_mainView->rect()));
+            update();
+        }
+    });
 }
 
 void NavigatorView::mousePressEvent(QMouseEvent *event)

--- a/app/settings.cpp
+++ b/app/settings.cpp
@@ -65,6 +65,11 @@ bool Settings::loopGallery() const
     return m_qsettings->value("loop_gallery", true).toBool();
 }
 
+bool Settings::autoLongImageMode() const
+{
+    return m_qsettings->value("auto_long_image_mode", true).toBool();
+}
+
 Settings::DoubleClickBehavior Settings::doubleClickBehavior() const
 {
     QString result = m_qsettings->value("double_click_behavior", "Close").toString();
@@ -114,6 +119,12 @@ void Settings::setUseLightCheckerboard(bool light)
 void Settings::setLoopGallery(bool on)
 {
     m_qsettings->setValue("loop_gallery", on);
+    m_qsettings->sync();
+}
+
+void Settings::setAutoLongImageMode(bool on)
+{
+    m_qsettings->setValue("auto_long_image_mode", on);
     m_qsettings->sync();
 }
 

--- a/app/settings.h
+++ b/app/settings.h
@@ -38,6 +38,7 @@ public:
     bool useBuiltInCloseAnimation() const;
     bool useLightCheckerboard() const;
     bool loopGallery() const;
+    bool autoLongImageMode() const;
     DoubleClickBehavior doubleClickBehavior() const;
     MouseWheelBehavior mouseWheelBehavior() const;
     WindowSizeBehavior initWindowSizeBehavior() const;
@@ -47,6 +48,7 @@ public:
     void setUseBuiltInCloseAnimation(bool on);
     void setUseLightCheckerboard(bool light);
     void setLoopGallery(bool on);
+    void setAutoLongImageMode(bool on);
     void setDoubleClickBehavior(DoubleClickBehavior dcb);
     void setMouseWheelBehavior(MouseWheelBehavior mwb);
     void setInitWindowSizeBehavior(WindowSizeBehavior wsb);

--- a/app/settingsdialog.cpp
+++ b/app/settingsdialog.cpp
@@ -23,6 +23,7 @@ SettingsDialog::SettingsDialog(QWidget *parent)
     , m_useBuiltInCloseAnimation(new QCheckBox)
     , m_useLightCheckerboard(new QCheckBox)
     , m_loopGallery(new QCheckBox)
+    , m_autoLongImageMode(new QCheckBox)
     , m_doubleClickBehavior(new QComboBox)
     , m_mouseWheelBehavior(new QComboBox)
     , m_initWindowSizeBehavior(new QComboBox)
@@ -123,6 +124,7 @@ SettingsDialog::SettingsDialog(QWidget *parent)
     settingsForm->addRow(tr("Use built-in close window animation"), m_useBuiltInCloseAnimation);
     settingsForm->addRow(tr("Use light-color checkerboard"), m_useLightCheckerboard);
     settingsForm->addRow(tr("Loop the loaded gallery"), m_loopGallery);
+    settingsForm->addRow(tr("Auto long image mode"), m_autoLongImageMode);
     settingsForm->addRow(tr("Double-click behavior"), m_doubleClickBehavior);
     settingsForm->addRow(tr("Mouse wheel behavior"), m_mouseWheelBehavior);
     settingsForm->addRow(tr("Default window size"), m_initWindowSizeBehavior);
@@ -132,6 +134,7 @@ SettingsDialog::SettingsDialog(QWidget *parent)
     m_useBuiltInCloseAnimation->setChecked(Settings::instance()->useBuiltInCloseAnimation());
     m_useLightCheckerboard->setChecked(Settings::instance()->useLightCheckerboard());
     m_loopGallery->setChecked(Settings::instance()->loopGallery());
+    m_autoLongImageMode->setChecked(Settings::instance()->autoLongImageMode());
     m_doubleClickBehavior->setModel(new QStringListModel(dcbDropDown));
     Settings::DoubleClickBehavior dcb = Settings::instance()->doubleClickBehavior();
     m_doubleClickBehavior->setCurrentIndex(static_cast<int>(dcb));
@@ -172,6 +175,10 @@ SettingsDialog::SettingsDialog(QWidget *parent)
 
     connect(m_loopGallery, &QCHECKBOX_CHECKSTATECHANGED, this, [ = ](QT_CHECKSTATE state){
         Settings::instance()->setLoopGallery(state == Qt::Checked);
+    });
+
+    connect(m_autoLongImageMode, &QCHECKBOX_CHECKSTATECHANGED, this, [ = ](QT_CHECKSTATE state){
+        Settings::instance()->setAutoLongImageMode(state == Qt::Checked);
     });
 
     connect(m_doubleClickBehavior, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [ = ](int index){

--- a/app/settingsdialog.h
+++ b/app/settingsdialog.h
@@ -26,6 +26,7 @@ private:
     QCheckBox * m_useBuiltInCloseAnimation = nullptr;
     QCheckBox * m_useLightCheckerboard = nullptr;
     QCheckBox * m_loopGallery = nullptr;
+    QCheckBox * m_autoLongImageMode = nullptr;
     QComboBox * m_doubleClickBehavior = nullptr;
     QComboBox * m_mouseWheelBehavior = nullptr;
     QComboBox * m_initWindowSizeBehavior = nullptr;


### PR DESCRIPTION
## Summary by Sourcery

Introduce auto long image mode to automatically detect and fit very tall or wide images, add a user preference to enable or disable it, and improve navigator viewport update timing.

New Features:
- Add auto long image mode in GraphicsView to detect and fit images with extreme aspect ratios by width or height
- Expose a new autoLongImageMode setting with a checkbox in the preferences dialog

Enhancements:
- Defer navigator viewport region calculations via a zero-delay QTimer and reset long image mode on manual zoom, fit, and actual size actions

Chores:
- Update the copyright year to 2025