### PR TITLE
Allow dragging window from titlebar when maximized

### DIFF
--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -346,7 +346,7 @@ void MainWindow::leaveEvent(QEvent *event)
 
 void MainWindow::mousePressEvent(QMouseEvent *event)
 {
-    if (event->buttons() & Qt::LeftButton && !isMaximized()) {
+    if (event->buttons() & Qt::LeftButton) {
         m_clickedOnWindow = true;
         m_oldMousePos = event->pos();
 //        qDebug() << m_oldMousePos << m_graphicsView->transform().m11()
@@ -359,7 +359,7 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
 
 void MainWindow::mouseMoveEvent(QMouseEvent *event)
 {
-    if (event->buttons() & Qt::LeftButton && m_clickedOnWindow && !isMaximized() && !isFullScreen()) {
+    if (event->buttons() & Qt::LeftButton && m_clickedOnWindow && !isFullScreen()) {
         if (!window()->windowHandle()->startSystemMove()) {
             move(event->globalPosition().toPoint() - m_oldMousePos);
         }

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -360,6 +360,10 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
 void MainWindow::mouseMoveEvent(QMouseEvent *event)
 {
     if (event->buttons() & Qt::LeftButton && m_clickedOnWindow && !isFullScreen()) {
+        if (isMaximized()){
+            window()->showNormal();
+        }
+        
         if (!window()->windowHandle()->startSystemMove()) {
             move(event->globalPosition().toPoint() - m_oldMousePos);
         }

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -346,7 +346,12 @@ void MainWindow::leaveEvent(QEvent *event)
 
 void MainWindow::mousePressEvent(QMouseEvent *event)
 {
-    if (event->buttons() & Qt::LeftButton) {
+    bool optionalMaximized = false;
+    #if defined(Q_OS_WIN)
+        optionalMaximized = isMaximized();
+    #endif
+
+    if (event->buttons() & Qt::LeftButton && !optionalMaximized && !isFullScreen()) {
         m_clickedOnWindow = true;
         m_oldMousePos = event->pos();
 //        qDebug() << m_oldMousePos << m_graphicsView->transform().m11()
@@ -359,7 +364,7 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
 
 void MainWindow::mouseMoveEvent(QMouseEvent *event)
 {
-    if (event->buttons() & Qt::LeftButton && m_clickedOnWindow && !isFullScreen()) {
+    if (event->buttons() & Qt::LeftButton && m_clickedOnWindow) {
         if (!window()->windowHandle()->startSystemMove()) {
             move(event->globalPosition().toPoint() - m_oldMousePos);
         }

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -360,10 +360,6 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
 void MainWindow::mouseMoveEvent(QMouseEvent *event)
 {
     if (event->buttons() & Qt::LeftButton && m_clickedOnWindow && !isFullScreen()) {
-        if (isMaximized()){
-            window()->showNormal();
-        }
-        
         if (!window()->windowHandle()->startSystemMove()) {
             move(event->globalPosition().toPoint() - m_oldMousePos);
         }

--- a/app/titlebar.cpp
+++ b/app/titlebar.cpp
@@ -129,8 +129,7 @@ void TitleBar::mouseMoveEvent(QMouseEvent *event)
         }
     }
 
-    if (event->buttons() & Qt::LeftButton && m_dragPending
-        && !window()->isMaximized() && !window()->isFullScreen()) {
+    if (event->buttons() & Qt::LeftButton && m_dragPending && !window()->isFullScreen()) {
         if (QWindow *wh = window()->windowHandle()) {
             if (!wh->startSystemMove())
                 window()->move(event->globalPosition().toPoint() - m_moveStartPos);

--- a/app/titlebar.cpp
+++ b/app/titlebar.cpp
@@ -131,6 +131,10 @@ void TitleBar::mouseMoveEvent(QMouseEvent *event)
 
     if (event->buttons() & Qt::LeftButton && m_dragPending && !window()->isFullScreen()) {
         if (QWindow *wh = window()->windowHandle()) {
+            if (isMaximized()){
+                wh->showNormal();
+            }
+            
             if (!wh->startSystemMove())
                 window()->move(event->globalPosition().toPoint() - m_moveStartPos);
         }

--- a/app/titlebar.cpp
+++ b/app/titlebar.cpp
@@ -129,7 +129,14 @@ void TitleBar::mouseMoveEvent(QMouseEvent *event)
         }
     }
 
-    if (event->buttons() & Qt::LeftButton && m_dragPending && !window()->isFullScreen()) {
+    bool optionalMaximized = false;
+    #if defined(Q_OS_WIN)
+        optionalMaximized = isMaximized();
+    #endif
+
+    if (event->buttons() & Qt::LeftButton && m_dragPending
+        && !window()->isFullScreen() && !optionalMaximized) {
+        
         if (QWindow *wh = window()->windowHandle()) {
             if (!wh->startSystemMove())
                 window()->move(event->globalPosition().toPoint() - m_moveStartPos);

--- a/app/titlebar.cpp
+++ b/app/titlebar.cpp
@@ -131,10 +131,6 @@ void TitleBar::mouseMoveEvent(QMouseEvent *event)
 
     if (event->buttons() & Qt::LeftButton && m_dragPending && !window()->isFullScreen()) {
         if (QWindow *wh = window()->windowHandle()) {
-            if (isMaximized()){
-                wh->showNormal();
-            }
-            
             if (!wh->startSystemMove())
                 window()->move(event->globalPosition().toPoint() - m_moveStartPos);
         }


### PR DESCRIPTION
This better matches titlebar behavior of Windows and KDE, and probably a lot more other environments, it also allows for easier unmaximizing because the current titlebar has no dedicated maximize/restore button.

## Summary by Sourcery

Enhancements:
- Relax window drag restriction to support dragging from the titlebar when the window is maximized but not fullscreen.