### PR TITLE
Maximize the window when the image size matches the screen size

### DIFF
--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -238,6 +238,13 @@ void MainWindow::adjustWindowSizeBySceneRect()
             // just call resetScale() here to ensure the thing is no longer scaled.
             m_graphicsView->resetScale();
             centerWindow();
+
+            // to avoid the window appearing maximized while not being actually maximized
+            // which is common when viewing screenshots of the same screen size
+            if (finalSize == screenSize) {
+                showMaximized();
+            }
+            
         } else {
             // toggle maximum
             showMaximized();

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -229,22 +229,22 @@ void MainWindow::adjustWindowSizeBySceneRect()
             // we can show the picture by increase the window size.
             QSize finalSize = (screenSize.expandedTo(sceneSizeWithMargins) == screenSize) ?
                               sceneSizeWithMargins : screenSize;
-            // We have a very reasonable sizeHint() value ;P
-            this->resize(finalSize.expandedTo(this->sizeHint()));
+
+            // to avoid the window appearing maximized while not being actually maximized
+            // which is common when viewing screenshots of the same screen size
+            if (finalSize == screenSize) {
+                showMaximized();
+            } else {
+                // We have a very reasonable sizeHint() value ;P
+                this->resize(finalSize.expandedTo(this->sizeHint()));
+                centerWindow();
+            }
 
             // We're sure the window can display the whole thing with 1:1 scale.
             // The old window size may cause fitInView call from resize() and the
             // above resize() call won't reset the scale back to 1:1, so we
             // just call resetScale() here to ensure the thing is no longer scaled.
             m_graphicsView->resetScale();
-            centerWindow();
-
-            // to avoid the window appearing maximized while not being actually maximized
-            // which is common when viewing screenshots of the same screen size
-            if (finalSize == screenSize) {
-                showMaximized();
-            }
-            
         } else {
             // toggle maximum
             showMaximized();


### PR DESCRIPTION
This is to avoid the window appearing maximized while not actually being maximized which leads to some frustration and confusion about window borders and breaking Fitts' law on the close button.

This is common for example when viewing screenshots of the same screen size.

## Summary by Sourcery

Enhancements:
- Automatically switch to a maximized window state when the adjusted window size matches the screen size to provide consistent window behavior.