### PR TITLE
Add an option to show/hide bird-eye view

### DIFF
--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -93,10 +93,14 @@ MainWindow::MainWindow(QWidget *parent)
 
     connect(m_graphicsView, &GraphicsView::navigatorViewRequired,
             this, [this](bool required, const QTransform & tf){
-        m_gv->setTransform(GraphicsView::resetScale(tf));
-        m_gv->fitInView(m_gv->sceneRect(), Qt::KeepAspectRatio);
-        m_gv->setVisible(required);
-        m_gv->updateMainViewportRegion();
+        if (Settings::instance()->showBirdEyeView()){
+            m_gv->setTransform(GraphicsView::resetScale(tf));
+            m_gv->fitInView(m_gv->sceneRect(), Qt::KeepAspectRatio);
+            m_gv->setVisible(required);
+            m_gv->updateMainViewportRegion();
+        } else {
+             m_gv->setVisible(false);
+        }
     });
 
     connect(m_graphicsView, &GraphicsView::viewportRectChanged,

--- a/app/settings.cpp
+++ b/app/settings.cpp
@@ -60,6 +60,11 @@ bool Settings::showTitleBar() const
     return m_qsettings->value("show_title_bar", true).toBool();
 }
 
+bool Settings::showBirdEyeView() const
+{
+    return m_qsettings->value("show_bird_eye_view", true).toBool();
+}
+
 bool Settings::useLightCheckerboard() const
 {
     return m_qsettings->value("use_light_checkerboard", false).toBool();
@@ -131,6 +136,12 @@ void Settings::setUseBuiltInCloseAnimation(bool on)
 void Settings::setShowTitleBar(bool on)
 {
     m_qsettings->setValue("show_title_bar", on);
+    m_qsettings->sync();
+}
+
+void Settings::setShowBirdEyeView(bool on)
+{
+    m_qsettings->setValue("show_bird_eye_view", on);
     m_qsettings->sync();
 }
 

--- a/app/settings.h
+++ b/app/settings.h
@@ -37,6 +37,7 @@ public:
     bool stayOnTop() const;
     bool useBuiltInCloseAnimation() const;
     bool showTitleBar() const;
+    bool showBirdEyeView() const;
     bool useLightCheckerboard() const;
     bool loopGallery() const;
     bool autoLongImageMode() const;
@@ -49,6 +50,7 @@ public:
     void setStayOnTop(bool on);
     void setUseBuiltInCloseAnimation(bool on);
     void setShowTitleBar(bool on);
+    void setShowBirdEyeView(bool on);
     void setUseLightCheckerboard(bool light);
     void setLoopGallery(bool on);
     void setAutoLongImageMode(bool on);

--- a/app/settingsdialog.cpp
+++ b/app/settingsdialog.cpp
@@ -126,7 +126,7 @@ SettingsDialog::SettingsDialog(QWidget *parent)
     settingsForm->addRow(tr("Stay on top when start-up"), m_stayOnTop);
     settingsForm->addRow(tr("Use built-in close window animation"), m_useBuiltInCloseAnimation);
     settingsForm->addRow(tr("Show title bar"), m_showTitleBar);
-    settingsForm->addRow(tr("Show bird-eye view"), m_showBirdEyeView);
+    settingsForm->addRow(tr("Show bird's-eye view"), m_showBirdEyeView);
     settingsForm->addRow(tr("Use light-color checkerboard"), m_useLightCheckerboard);
     settingsForm->addRow(tr("Loop the loaded gallery"), m_loopGallery);
     settingsForm->addRow(tr("Auto long image mode"), m_autoLongImageMode);

--- a/app/settingsdialog.cpp
+++ b/app/settingsdialog.cpp
@@ -22,6 +22,7 @@ SettingsDialog::SettingsDialog(QWidget *parent)
     , m_stayOnTop(new QCheckBox)
     , m_useBuiltInCloseAnimation(new QCheckBox)
     , m_showTitleBar(new QCheckBox)
+    , m_showBirdEyeView(new QCheckBox)
     , m_useLightCheckerboard(new QCheckBox)
     , m_loopGallery(new QCheckBox)
     , m_autoLongImageMode(new QCheckBox)
@@ -125,6 +126,7 @@ SettingsDialog::SettingsDialog(QWidget *parent)
     settingsForm->addRow(tr("Stay on top when start-up"), m_stayOnTop);
     settingsForm->addRow(tr("Use built-in close window animation"), m_useBuiltInCloseAnimation);
     settingsForm->addRow(tr("Show title bar"), m_showTitleBar);
+    settingsForm->addRow(tr("Show bird-eye view"), m_showBirdEyeView);
     settingsForm->addRow(tr("Use light-color checkerboard"), m_useLightCheckerboard);
     settingsForm->addRow(tr("Loop the loaded gallery"), m_loopGallery);
     settingsForm->addRow(tr("Auto long image mode"), m_autoLongImageMode);
@@ -137,6 +139,7 @@ SettingsDialog::SettingsDialog(QWidget *parent)
     m_stayOnTop->setChecked(Settings::instance()->stayOnTop());
     m_useBuiltInCloseAnimation->setChecked(Settings::instance()->useBuiltInCloseAnimation());
     m_showTitleBar->setChecked(Settings::instance()->showTitleBar());
+    m_showBirdEyeView->setChecked(Settings::instance()->showBirdEyeView());
     m_useLightCheckerboard->setChecked(Settings::instance()->useLightCheckerboard());
     m_loopGallery->setChecked(Settings::instance()->loopGallery());
     m_autoLongImageMode->setChecked(Settings::instance()->autoLongImageMode());
@@ -177,6 +180,10 @@ SettingsDialog::SettingsDialog(QWidget *parent)
 
     connect(m_showTitleBar, &QCHECKBOX_CHECKSTATECHANGED, this, [ = ](QT_CHECKSTATE state){
         Settings::instance()->setShowTitleBar(state == Qt::Checked);
+    });
+
+    connect(m_showBirdEyeView, &QCHECKBOX_CHECKSTATECHANGED, this, [ = ](QT_CHECKSTATE state){
+        Settings::instance()->setShowBirdEyeView(state == Qt::Checked);
     });
 
     connect(m_useLightCheckerboard, &QCHECKBOX_CHECKSTATECHANGED, this, [ = ](QT_CHECKSTATE state){

--- a/app/settingsdialog.h
+++ b/app/settingsdialog.h
@@ -25,6 +25,7 @@ private:
     QCheckBox * m_stayOnTop = nullptr;
     QCheckBox * m_useBuiltInCloseAnimation = nullptr;
     QCheckBox * m_showTitleBar = nullptr;
+    QCheckBox * m_showBirdEyeView = nullptr;
     QCheckBox * m_useLightCheckerboard = nullptr;
     QCheckBox * m_loopGallery = nullptr;
     QCheckBox * m_autoLongImageMode = nullptr;


### PR DESCRIPTION
Adds an option that controls whether the bird-eye view (NavigatorView) appears when zooming in or not.

## Summary by Sourcery

Add a configurable setting to control the visibility of the bird-eye (navigator) view when zooming.

New Features:
- Introduce a persistent user setting to toggle the bird-eye view on or off.
- Expose the bird-eye view visibility option in the settings dialog via a new checkbox.