### PR TITLE
Fix close button without titlebar position in RTL

### DIFF
--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -630,7 +630,7 @@ void MainWindow::updateWidgetsPosition()
 {
     if (m_titleBar->closeButtonOnly()) {
         const int bw = m_titleBar->closeButtonWidth();
-        m_titleBar->setGeometry(width() - bw, 0, bw, m_titleBar->height());
+        m_titleBar->setGeometry(isRightToLeft() ? 0 : width() - bw, 0, bw, m_titleBar->height());
     } else {
         m_titleBar->setGeometry(0, 0, width(), m_titleBar->height());
     }


### PR DESCRIPTION
Fix an edge case missed in #182 where if Show titlebar was disabled, the lone close button would appear on the right instead of on the left in RTL mode.

## Summary by Sourcery

Bug Fixes:
- Fix close button placement in RTL mode when only the close button is shown without the full title bar.